### PR TITLE
feat: Implement granular error reporting for frontend debug view

### DIFF
--- a/SQL_analyzer/src/stores/sqlStore.js
+++ b/SQL_analyzer/src/stores/sqlStore.js
@@ -1,6 +1,7 @@
 // src/stores/sqlStore.js
 import { defineStore } from 'pinia'
 import { ref } from 'vue'
+import { useLogStore } from './logStore' // Import logStore
 
 // API configuration
 const API_BASE_URL = 'http://localhost:8000'
@@ -59,6 +60,14 @@ export const useSqlStore = defineStore('sql', () => {
         results.value = response.formatted_results
         statistics.value = response.statistics
         componentsCount.value = response.statistics.total
+
+        // Log parsing issues
+        if (response.parsing_issues && response.parsing_issues.length > 0) {
+          const logStore = useLogStore()
+          response.parsing_issues.forEach(issue => {
+            logStore.addLog(issue.type.toUpperCase(), issue.message)
+          })
+        }
       } else {
         // Handle API error response
         throw new Error(response.message || 'Processing failed')

--- a/SQL_analyzer_backend/main.py
+++ b/SQL_analyzer_backend/main.py
@@ -54,6 +54,12 @@ class Component(BaseModel):
     content: Optional[str] = Field(None, description="Component content")
     declaration: Optional[str] = Field(None, description="Full declaration for table variables/temp tables")
 
+class ParsingIssueItem(BaseModel):
+    type: str = Field(..., description="Type of the parsing issue (e.g., warning, error)")
+    message: str = Field(..., description="Detailed message of the issue")
+    component_name: Optional[str] = Field(None, description="Name of the component related to the issue")
+    position: Optional[int] = Field(None, description="Position in the SQL string where the issue occurred")
+
 class Query(BaseModel):
     name: str = Field(..., description="Query name")
     query: str = Field(..., description="Generated SQL query")
@@ -70,6 +76,7 @@ class SqlProcessResponse(BaseModel):
     queries: List[Query] = Field(default=[], description="Generated queries")
     statistics: Statistics = Field(..., description="Component statistics")
     formatted_results: str = Field(..., description="Formatted results for display")
+    parsing_issues: List[ParsingIssueItem] = Field(default=[], description="List of parsing issues encountered")
 
 class HealthResponse(BaseModel):
     status: str = Field(..., description="Health status")
@@ -151,15 +158,26 @@ async def process_sql(request: SqlProcessRequest):
                 components=[],
                 queries=[],
                 statistics=Statistics(total=0, breakdown={}),
-                formatted_results=f"Error: {error_message}"
+                formatted_results=f"Error: {error_message}",
+                parsing_issues=[]
             )
         
         # Extract components using the SQL parser
-        raw_components = extract_components(
+        raw_components, parsing_issues_raw = extract_components(
             request.sql_query, 
             include_subqueries=request.include_subqueries
         )
         
+        # Convert raw parsing issues to Pydantic models
+        parsing_issues_response: List[ParsingIssueItem] = []
+        for issue_raw in parsing_issues_raw:
+            parsing_issues_response.append(ParsingIssueItem(
+                type=issue_raw.get('type', 'unknown'),
+                message=issue_raw.get('message', 'No message'),
+                component_name=issue_raw.get('component_name'),
+                position=issue_raw.get('position')
+            ))
+
         # Convert to Pydantic models
         components = []
         for comp in raw_components:
@@ -195,7 +213,8 @@ async def process_sql(request: SqlProcessRequest):
             components=components,
             queries=queries,
             statistics=statistics,
-            formatted_results=formatted_results
+            formatted_results=formatted_results,
+            parsing_issues=parsing_issues_response
         )
         
     except Exception as e:
@@ -209,7 +228,8 @@ async def process_sql(request: SqlProcessRequest):
             components=[],
             queries=[],
             statistics=Statistics(total=0, breakdown={}),
-            formatted_results=f"Error: {str(e)}"
+            formatted_results=f"Error: {str(e)}",
+            parsing_issues=[]
         )
 
 @app.post("/api/sql/validate")


### PR DESCRIPTION
This change enhances error reporting by providing more specific parsing issue details from the backend to the frontend.

Backend changes:
- `sql_parser.py` now collects detailed parsing warnings/errors (e.g., mismatched parentheses in CTEs) into a list, including issue type, message, component name, and position. It returns this list alongside the extracted components.
- `main.py` (FastAPI backend) has an updated `SqlProcessResponse` model to include `parsing_issues: List[ParsingIssueItem]`. This list is populated with the details from `sql_parser.py`.

Frontend changes:
- `sqlStore.js` now processes the `parsing_issues` field from the backend response.
- For each issue, it calls `logStore.addLog` with the appropriate level (e.g., 'WARNING', 'ERROR') and the detailed message.
- `DebugLogTab.vue` displays these granular messages without modification, as it's already designed to show logs from `logStore` with level-specific styling.

This allows you to see more specific feedback on your SQL queries directly in the debug log view, improving the debugging experience.